### PR TITLE
Explicitly expose the default dokku port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,5 @@ RUN npm run build
 FROM nginx
 COPY app/ /usr/share/nginx/html
 COPY --from=build /app/main.js /usr/share/nginx/html/js/main.js
+
+EXPOSE 5000


### PR DESCRIPTION
Dokku serves containers at port 5000 by default, nginx serves at port 80 by default.  We can (and currently do) map the ports in dokku with `dokku proxy:ports-add trials-tracker http:80:80 https:443:80`, but this is different to many of our other apps, so keep things consistent we're moving that configuration into the Dockerfile.

Ref #14 